### PR TITLE
Add ${userHome} substitution support for apc.imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Import CSS and JavaScript files to customize the look and feel of VS Code
       "/Users/some/path/style.css",
       "/Users/some/path/script.js",
       "/C:/Users/path/style.css", // for Windows
+      "${userHome}/path/style.css", // ${userHome} currently only supported
 
       // or see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
       // Local file imports like this are not watched in real time

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -179,9 +179,10 @@ define(['exports', 'apc/auxiliary', 'apc/configuration'], (exports, auxiliary, c
               }
             }
             else if (typeof path === 'string' && path.match(/(\.css|\.js)$/)) {
-              const URI = uri.URI.parse(!path.startsWith('file://') ? 'file://' + path : path);
+              const substitutedPath = path.replace('${userHome}', services.environmentService.userHome.path);
+              const URI = uri.URI.parse(!substitutedPath.startsWith('file://') ? 'file://' + substitutedPath : substitutedPath);
               const data = await services.fileService.readFile(URI);
-              const isCss = path.endsWith('.css');
+              const isCss = substitutedPath.endsWith('.css');
 
               if (isCss) {
                 const disposable = services.fileService.watch(URI);


### PR DESCRIPTION
This change adds `${userHome}` substitution as in `tasks.json` or `launch.json` and makes integration of VSCode on multiple devices (work, private, etc...) easier, where each device can have different home path.

More variables can be added, maybe https://github.com/connor4312/vscode-variables might be taken into account in the future if needed.

```json
"apc.imports": [
    "file://${userHome}/.vscode/extensions/brandonkirbyson.vscode-animations-2.0.1/dist/updateHandler.js"
],
```

or 

```json
"apc.imports": [
    "${userHome}/.vscode/extensions/brandonkirbyson.vscode-animations-2.0.1/dist/updateHandler.js"
],
```