### PR TITLE
Updated README.md for VSCode 1.86 version fixing hiding the title bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Configures the Electron window. For detailed info, see the [Electron BrowserWind
     "apc.electron": {
       "titleBarStyle": "hidden",
     },
-    "window.titleBarStyle": "native"
+    "window.titleBarStyle": "native",
+    "window.customTitleBarVisibility": "never",
 ```
 
 #### inline title bar with traffic light position


### PR DESCRIPTION
Fixes issue:
- #146 