### PR TITLE
fix: check if the activity bar config is enabled on init

### DIFF
--- a/vs/modules/layout.activitybar.js
+++ b/vs/modules/layout.activitybar.js
@@ -143,7 +143,7 @@ define(
 
       exports.init = function () {
         try {
-          if (store.zenMode) { return; };
+          if (store.zenMode || !config.activityBar.isEnabled) { return; };
           const { size, position } = config.activityBar;
 
           if (!store.previousActivityBarConfig.position && position) {


### PR DESCRIPTION
fix https://github.com/drcika/apc-extension/issues/172